### PR TITLE
Add basic a11y support

### DIFF
--- a/packages/app/configs/11ty/11ty.config.js
+++ b/packages/app/configs/11ty/11ty.config.js
@@ -20,6 +20,7 @@ module.exports = function (config) {
   config.addFilter('version', filters.version)
   config.addFilter('readableDate', filters.readableDate)
   config.addFilter('readableDateShort', filters.readableDateShort)
+  config.addFilter('readableDateLocalazed', filters.readableDateLocalazed)
   config.addFilter('random', filters.swapListItem)
   config.addFilter('relatedPosts', filters.relatedPosts)
   config.addFilter('toJSON', filters.toJSON)

--- a/packages/app/configs/11ty/collections/getPopularPosts.js
+++ b/packages/app/configs/11ty/collections/getPopularPosts.js
@@ -1,7 +1,19 @@
 const getAllPosts = require('./getAllPosts')
 
+const currentYear = new Date().getFullYear()
+
+function getAdjustedLikes(post) {
+  const postYear = (new Date(post.date)).getFullYear()
+  const yearDiff = currentYear - postYear
+  const adjustedLikes = Math.max(0.5, 1 - (yearDiff / 10))
+
+  return Math.round(post.data.likes * adjustedLikes)
+}
+
 module.exports = function getPopularPostsCollection(collection) {
   const allPosts = getAllPosts(collection)
 
-  return allPosts.sort((a, b) => b.data.likes - a.data.likes).slice(0, 3)
+  return allPosts
+    .sort((a, b) => getAdjustedLikes(b) - getAdjustedLikes(a))
+    .slice(0, 3)
 }

--- a/packages/app/configs/11ty/filters/index.js
+++ b/packages/app/configs/11ty/filters/index.js
@@ -1,6 +1,7 @@
 const htmlDateString = require(`./htmlDateString`)
 const readableDate = require(`./readableDate`)
 const readableDateShort = require(`./readableDateShort`)
+const readableDateLocalazed = require(`./readableDateLocalazed`)
 const swapListItem = require(`./swapListItem`)
 const head = require(`./head`)
 const toJSON = require(`./toJSON`)
@@ -13,6 +14,7 @@ module.exports = {
   htmlDateString,
   readableDate,
   readableDateShort,
+  readableDateLocalazed,
   swapListItem,
   head,
   toJSON,

--- a/packages/app/configs/11ty/filters/readableDateLocalazed.js
+++ b/packages/app/configs/11ty/filters/readableDateLocalazed.js
@@ -1,0 +1,5 @@
+module.exports = (dateObj) => {
+  return new Intl.DateTimeFormat('ru-RU', {
+    dateStyle: 'long',
+  }).format(dateObj)
+}

--- a/packages/app/src/_data/projects.json
+++ b/packages/app/src/_data/projects.json
@@ -1,19 +1,48 @@
 [
   {
     "title": "Квиз по JavaScript",
+    "description": "Квиз на знание JavaScript из 13 вопросов",
     "url": "/javascript-quiz/",
-    "theme": "dark"
+    "theme": "dark",
+    "notes": "2019"
   },
   {
-    "title": "Авторский телеграм канал о разработке",
+    "title": "vdom130",
+    "description": "Свой VirtualDOM на 130 строк кода",
+    "url": "https://github.com/noveogroup-amorgunov/vdom130",
+    "theme": "dark",
+    "notes": "2020"
+  },
+  {
+    "title": "t.me/amorgunov",
+    "description": "Авторский телеграм канал о разработке",
     "url": "https://t.me/amorgunov",
     "coverImage": "/assets/images/common/project-telegram.png",
-    "theme": "dark"
+    "theme": "dark",
+    "notes": "с 2019"
   },
   {
-    "title": "Обучающий youtube-канал о фронтенде «Typing Away»",
+    "title": "@typingaway",
+    "description": "Обучающий YouTube-канал о фронтенде «AM»",
     "url": "https://www.youtube.com/@typingaway",
     "coverImage": "/assets/images/common/project-youtube.png",
-    "theme": "light"
+    "theme": "light",
+    "notes": "с 2023"
+  },
+  {
+    "title": "nukeapp",
+    "description": "Легендарное приложение кроссовок на основе React + Feature-Sliced Design",
+    "url": "https://github.com/noveogroup-amorgunov/nukeapp",
+    "theme": "dark",
+    "color": "#5f0951",
+    "notes": "с 2023"
+  },
+  {
+    "title": "fsd-lessons",
+    "description": "Монорепа с уроками по Feature-Sliced Design",
+    "url": "https://github.com/noveogroup-amorgunov/fsd-lessons",
+    "theme": " dark",
+    "color": "#030533",
+    "notes": "с 2025"
   }
 ]

--- a/packages/app/src/_data/talks.json
+++ b/packages/app/src/_data/talks.json
@@ -1,0 +1,82 @@
+{
+  "2025": [
+    {
+      "conferenceUrl": "https://15.codefest.ru/lecture/2883",
+      "slidesUrl": "https://docs.google.com/presentation/d/1tt7S4W00qkw9TTx8N7Tv-h5S_29vJOTvbQNOZ8TfBms/edit?usp=sharing",
+      "materialsUrl": "https://gist.github.com/noveogroup-amorgunov/a8458105ca6b72164202d596271269e4",
+      "title": "Используем различные архитектуры внутри FSD",
+      "conference": "CodeFest 15",
+      "year": "2025"
+    },
+    {
+      "conferenceUrl": "https://holyjs.ru/archive/2025%20Spring/talks/d67e83dfbf544b7891971a07c8107191/",
+      "slidesUrl": "https://docs.google.com/presentation/d/1scB6qmqjP8R0pvJW7PLozNUUwmC38VgQjaGamviF7Ck/edit?usp=sharing",
+      "materialsUrl": "https://gist.github.com/noveogroup-amorgunov/20af2f1596fdef7409bd918d7281af45",
+      "title": "Воркшоп: Используем различные архитектуры внутри FSD",
+      "conference": "HolyJS 2025",
+      "year": "2025"
+    }
+  ],
+  "2024": [
+    {
+      "conferenceUrl": "https://holyjs.ru/talks/1025b2f91f5e48fc8598e6a990697a2e",
+      "videoUrl": "https://www.youtube.com/watch?v=H_rJ0zB8rqc",
+      "slidesUrl": "https://docs.google.com/presentation/d/1W3xmFgfcIssZY9Pg9VnNAbUBCA665V3QzQtTdkcmo00/edit",
+      "materialsUrl": "https://gist.github.com/noveogroup-amorgunov/cd70296d5c4246a53f14a11d498a809c",
+      "title": "Разбираемся в Feature-Sliced Design",
+      "conference": "HolyJS 2024 Autumn",
+      "year": "2024"
+    },
+    {
+      "conferenceUrl": "https://events.yandex.ru/events/ya-love-frontend-2024",
+      "videoUrl": "https://www.youtube.com/watch?v=M84x3pzDYr0",
+      "slidesUrl": "https://docs.google.com/presentation/d/1zHaieuqyiW95witifD9rO0-nnj5GmjzzPkDGvhWft6s/edit?usp=sharing",
+      "materialsUrl": "https://gist.github.com/noveogroup-amorgunov/014965078e55de811dcf8b3ad9351de0",
+      "title": "Копаем глубже в Feature-Sliced Design",
+      "conference": "Я <3 Фронтенд",
+      "year": "2024"
+    },
+    {
+      "conferenceUrl": "https://moscowjs.org/events/moscowjs-58",
+      "videoUrl": "https://www.youtube.com/watch?v=1RHxFJhLrQk",
+      "slidesUrl": "https://docs.google.com/presentation/d/1bbWxYGwKJ9HOFm8K81LWTVJ6hbLrLzAqZW2oN1U9luI/edit?usp=sharing",
+      "materialsUrl": "https://gist.github.com/noveogroup-amorgunov/dd179ba9e41fe06ff327d5d6a2d296a9",
+      "title": "Темная сторона NextJS",
+      "conference": "MoscowJS #58",
+      "year": "2024"
+    }
+  ],
+  "2022": [
+    {
+      "videoUrl": "https://www.youtube.com/watch?v=4S5VDv6Ximk",
+      "title": "Тестирование в современном фронтенде",
+      "conference": "Samokat_tech Meetup",
+      "year": "2022"
+    },
+    {
+      "videoUrl": "https://www.youtube.com/watch?v=_HM76ktNcTA",
+      "slidesUrl": "https://docs.google.com/presentation/d/16XdAl52GuCE1BJlWB0kMaSEhP6Xrv2r0w5ULU5tMQ6Y/edit?usp=sharing",
+      "title": "Как писать интеграционные тесты",
+      "conference": "Samokat_tech Meetup",
+      "year": "2022"
+    }
+  ],
+  "2020": [
+    {
+      "conferenceUrl": "https://events.yandex.ru/events/js_party/30oct",
+      "slidesUrl": "https://docs.google.com/presentation/d/1eSqDMmGEQjnnP5Jj0DZEzh-Vm7F_YHkcwN4V0SgQhcg/edit?usp=sharing",
+      "title": "Разбираемся с бессерверными технологиями",
+      "conference": "JS Party Яндекс.Маркета",
+      "year": "2020"
+    }
+  ],
+  "2019": [
+    {
+      "videoUrl": "https://www.youtube.com/watch?v=CjDaePioMf0",
+      "slidesUrl": "https://docs.google.com/presentation/d/1-OdgdBfRWRJL4shq1IS8PLhePk0RL5d9-G7QdADdRbs/edit?usp=sharing",
+      "title": "SSR в React",
+      "conference": "ReactNSK #2",
+      "year": "2019"
+    }
+  ]
+}

--- a/packages/app/src/_includes/components/a11y-skip-to-content.hbs
+++ b/packages/app/src/_includes/components/a11y-skip-to-content.hbs
@@ -1,0 +1,1 @@
+<button id="a11y-skip-to-content" type="button">Пропустить</button>

--- a/packages/app/src/_includes/components/footer.hbs
+++ b/packages/app/src/_includes/components/footer.hbs
@@ -1,20 +1,24 @@
-<div class="footer">
-  <div class="footer__item">
-    {{#> components/text type="caption"}}
-      Powered by
-      {{#> components/text type="captionStrong"}}
-        {{#> components/link href="#"}}11ty{{/ components/link}}
-      {{/ components/text}}
-    {{/ components/text}}
-  </div>
-  <div class="footer__item footer__item_divider">
-    {{#> components/text type="captionStrong"}} | {{/ components/text}}
-  </div>
-  <div class="footer__item">
-    {{#> components/text type="caption"}}
-      {{#> components/link href=(append "https://github.com/noveogroup-amorgunov/amorgunov.com/tree/master/" page.inputPath) }}
-        Редактировать страницу на GitHub
-      {{/ components/link}}
-    {{/ components/text}}
-  </div>
-</div>
+<footer class="footer">
+  <nav>
+    <ul class="footer__list">
+      <li class="footer__item">
+        {{#> components/text type="caption"}}
+          Powered by
+          {{#> components/text type="captionStrong"}}
+            {{#> components/link href="#"}}11ty{{/ components/link}}
+          {{/ components/text}}
+        {{/ components/text}}
+      </li>
+      <li class="footer__item footer__item_divider" aria-hidden="true">
+        {{#> components/text type="captionStrong"}} | {{/ components/text}}
+      </li>
+      <li class="footer__item">
+        {{#> components/text type="caption"}}
+          {{#> components/link href=(append "https://github.com/noveogroup-amorgunov/amorgunov.com/tree/master/" page.inputPath) }}
+            Редактировать страницу на GitHub
+          {{/ components/link}}
+        {{/ components/text}}
+      </li>
+    </ul>
+  </nav>
+</footer>

--- a/packages/app/src/_includes/components/header.hbs
+++ b/packages/app/src/_includes/components/header.hbs
@@ -1,8 +1,21 @@
 <header class="header">
   {{> components/a11y-skip-to-content }}
   <a href="{{#if (eq page.url '/blog/')}}/{{else}}/blog{{/if}}" class="header__logo" aria-label="Главная страница"></a>
-  <nav aria-label="Действия" class="header__right">
+  <div class="header__actions">
+    <nav aria-label="Ссылки по разделам" class="header__nav">
+      <ul class="header__nav-list">
+        <li{{#if (eq page.url '/blog/')}} aria-current="true"{{/if}}>
+          <a href="/blog/">Посты</a>
+        </li>
+        <li{{#if (eq page.url '/projects/')}} aria-current="true"{{/if}}>
+          <a href="/projects/">Проекты</a>
+        </li>
+        <li{{#if (eq page.url '/talks/')}} aria-current="true"{{/if}}>
+          <a href="/talks/">Talks</a>
+        </li>
+      </ul>
+    </nav>
     <button aria-label="Сменить тему" class="icon header__theme-toggler" />
     <button aria-label="Открыть меню" class="icon header__menu-toggler" />
-  </nav>
+  </div>
 </header>

--- a/packages/app/src/_includes/components/header.hbs
+++ b/packages/app/src/_includes/components/header.hbs
@@ -1,7 +1,8 @@
-<div class="header">
-  <a href="{{#if (eq page.url '/blog/')}}/{{else}}/blog{{/if}}" class="header__logo"></a>
-  <div class="header__right">
-    <a href="#" class="icon header__theme-toggler"></a>
-    <a href="#" class="icon header__menu-toggler"></a>
-  </div>
-</div>
+<header class="header">
+  {{> components/a11y-skip-to-content }}
+  <a href="{{#if (eq page.url '/blog/')}}/{{else}}/blog{{/if}}" class="header__logo" aria-label="Главная страница"></a>
+  <nav aria-label="Действия" class="header__right">
+    <button aria-label="Сменить тему" class="icon header__theme-toggler" />
+    <button aria-label="Открыть меню" class="icon header__menu-toggler" />
+  </nav>
+</header>

--- a/packages/app/src/_includes/components/menu.hbs
+++ b/packages/app/src/_includes/components/menu.hbs
@@ -1,17 +1,19 @@
 <dialog class="menu">
-  <nav aria-label="Ссылки по разделам" class="menu__nav">
-    <ul class="menu__nav-list">
-      <li{{#if (eq page.url '/blog/')}} aria-current="true"{{/if}}>
-        <a href="/blog/">Посты</a>
-      </li>
-      <li{{#if (eq page.url '/projects/')}} aria-current="true"{{/if}}>
-        <a href="/projects/">Проекты</a>
-      </li>
-      <li{{#if (eq page.url '/talks/')}} aria-current="true"{{/if}}>
-        <a href="/talks/">Talks</a>
-      </li>
-    </ul>
-  </nav>
+  <div class="menu__content">
+    <nav aria-label="Ссылки по разделам" class="menu__nav">
+      <ul class="menu__nav-list">
+        <li{{#if (eq page.url '/blog/')}} aria-current="true"{{/if}}>
+          <a href="/blog/">Посты</a>
+        </li>
+        <li{{#if (eq page.url '/projects/')}} aria-current="true"{{/if}}>
+          <a href="/projects/">Проекты</a>
+        </li>
+        <li{{#if (eq page.url '/talks/')}} aria-current="true"{{/if}}>
+          <a href="/talks/">Talks</a>
+        </li>
+      </ul>
+    </nav>
+  </div>
   {{!-- <section class="menu__block" aria-label="Популярные теги">
     {{> components/tag-list-with-bullet tags=(reverse (head collections.tagsWithPostsCount -8))}}
   </section> --}}

--- a/packages/app/src/_includes/components/menu.hbs
+++ b/packages/app/src/_includes/components/menu.hbs
@@ -1,27 +1,19 @@
-<div class="menu">
-  <div class="menu__overlay"></div>
-  <div class="menu__content">
-    <div class="menu__header">
-      <a href="/" class="menu__logo"></a>
-      <a href="#" class="icon menu__toggler"></a>
-    </div>
-    <div class="menu__block">
-      Здесь должно быть что-то очень полезное и доступное на всех страницах блога,
-      но к сожалению чего-то по настоящему стоящего я придумать не смог. Поэтому
-      чекайте самые популярные теги на блоге и последние посты.
-    </div>
-    <div class="menu__block">
-      {{#> components/text type="captionStrong" class="menu__block-header"}}
-        {{#> components/link href="#"}}Популярные теги{{/ components/link}}
-      {{/ components/text}}
-
-      {{> components/tag-list-with-bullet tags=(reverse (head collections.tagsWithPostsCount -8))}}
-    </div>
-    <div class="menu__block">
-      {{#> components/text type="captionStrong" class="menu__block-header"}}
-        {{#> components/link href="#"}}Последние посты{{/ components/link}}
-      {{/ components/text}}
-      {{> components/post-list compact="1" posts=(reverse (head collections.posts 2))}}
-    </div>
-  </div>
-</div>
+<dialog class="menu">
+  <nav aria-label="Ссылки по разделам" class="menu__nav">
+    <ul class="menu__nav-list">
+      <li{{#if (eq page.url '/blog/')}} aria-current="true"{{/if}}>
+        <a href="/blog/">Посты</a>
+      </li>
+      <li{{#if (eq page.url '/projects/')}} aria-current="true"{{/if}}>
+        <a href="/projects/">Проекты</a>
+      </li>
+      <li{{#if (eq page.url '/talks/')}} aria-current="true"{{/if}}>
+        <a href="/talks/">Talks</a>
+      </li>
+    </ul>
+  </nav>
+  {{!-- <section class="menu__block" aria-label="Популярные теги">
+    {{> components/tag-list-with-bullet tags=(reverse (head collections.tagsWithPostsCount -8))}}
+  </section> --}}
+  <button type="button" class="icon menu__toggler"></button>
+</dialog>

--- a/packages/app/src/_includes/components/pagination.hbs
+++ b/packages/app/src/_includes/components/pagination.hbs
@@ -1,20 +1,24 @@
-<section class="pagination-container">
-  <nav class="pagination">
+<nav class="pagination" role="navigation" aria-label="Переход по страницам">
+  <ul>
     {{#if pagination.nextPageLink}}
-      {{#> components/text type="body"}}
-        {{#> components/link class="pagination__item" rel="prev" href=(append "/blog/page/" (JSONstringify (plus pagination.pageNumber 1)))}}К старым постам{{/ components/link}}
-      {{/ components/text}}
+      <li>
+        {{#> components/text type="body"}}
+          {{#> components/link class="pagination__item" rel="prev" href=(append "/blog/page/" (JSONstringify (plus pagination.pageNumber 1)))}}К старым постам{{/ components/link}}
+        {{/ components/text}}
+      </li>
     {{/if}}
     {{#if pagination.previousPageLink}}
-      {{#if (eq pagination.pageNumber 1)}}
-      {{#> components/text type="body"}}
-        {{#> components/link class="pagination__item" rel="next" href="/blog"}}К новым{{/ components/link}}
-      {{/ components/text}}
-      {{else}}
+      <li>
+        {{#if (eq pagination.pageNumber 1)}}
         {{#> components/text type="body"}}
-          {{#> components/link class="pagination__item" rel="next" href=(append "/blog/page/" (JSONstringify (plus pagination.pageNumber -1)))}}К новым{{/ components/link}}
+          {{#> components/link class="pagination__item" rel="next" href="/blog"}}К новым{{/ components/link}}
         {{/ components/text}}
-      {{/if}}
+        {{else}}
+          {{#> components/text type="body"}}
+            {{#> components/link class="pagination__item" rel="next" href=(append "/blog/page/" (JSONstringify (plus pagination.pageNumber -1)))}}К новым{{/ components/link}}
+          {{/ components/text}}
+        {{/if}}
+      </li>
     {{/if}}
-  </nav>
-</section>
+  </ul>
+</nav>

--- a/packages/app/src/_includes/components/post-list.hbs
+++ b/packages/app/src/_includes/components/post-list.hbs
@@ -1,18 +1,31 @@
-<div class="post-list{{#if popular}} post-list_popular{{/if}}{{#if compact}} post-list_compact{{/if}}">
-  {{#each (reverse posts) as |post|}}
-    <a href="{{post.url}}" class="post-list__card{{#if post.data.bg}} post-list__card_light{{/if}}"{{#if post.data.bg}} style="background-image: url('{{post.data.bg}}')"{{/if}}>
-      {{#> components/text as="h3" type="h3" class="post-list__card-title"}}
-        {{post.data.title}}
-      {{/ components/text}}
-      {{#> components/text as="div" type="captionStrong" class="post-list__card-date"}}
-        {{readableDate post.date}}
-      {{/ components/text}}
-      {{#> components/text as="div" class="post-list__card-annotation"}}
-        {{post.data.description}}
-      {{/ components/text}}
-      <div class="post-list__card-likes" title="Количество реакций на пост">
-        {{post.data.likes}}
-      </div>
-    </a>
-  {{/each}}
-</div>
+<nav{{#if postListTitle}} aria-label="{{postListTitle}}"{{/if}}>
+  <ul class="post-list{{#if popular}} post-list_popular{{/if}}{{#if compact}} post-list_compact{{/if}}">
+    {{#each (reverse posts) as |post|}}
+      <li class="post-list__card{{#if post.data.bg}} post-list__card_light{{/if}}"{{#if post.data.bg}} style="background-image: url('{{post.data.bg}}')"{{/if}}>
+        <a href="{{post.url}}">
+          <span class="visually-hidden">{{post.data.title}}</span>
+        </a>
+        <div class="post-list__card-content">
+          <span aria-hidden="true" class="post-list__card-title">
+            {{#> components/text as="h3" type="h3"}}
+              {{post.data.title}}
+            {{/ components/text}}
+          </span>
+          <div class="visually-hidden">Дата написания поста – {{readableDateLocalazed post.date}}</div>
+          <span aria-hidden="true" class="post-list__card-date">
+            {{#> components/text as="div" type="captionStrong"}}
+              {{readableDate post.date}}
+            {{/ components/text}}
+          </span>
+          {{#> components/text as="div" class="post-list__card-annotation"}}
+            {{post.data.description}}
+          {{/ components/text}}
+          <div class="visually-hidden">Количество реакций на пост – {{post.data.likes}}</div>
+          <div class="post-list__card-likes" aria-hidden="true">
+            {{post.data.likes}}
+          </div>
+        </div>
+      </li>
+    {{/each}}
+  </ul>
+</nav>

--- a/packages/app/src/_includes/components/project-list.hbs
+++ b/packages/app/src/_includes/components/project-list.hbs
@@ -2,12 +2,17 @@
   <ul class="project-list">
     {{#each (reverse projects) as |project|}}
       <li>
-        <a rel="noreferrer external" target="_blank" href="{{project.url}}" class="project-list__card {{project.theme}}" style="background-image: url({{project.coverImage}});">
+        <a rel="noreferrer external" target="_blank" href="{{project.url}}" class="project-list__card {{project.theme}}" style="{{#if project.coverImage}}background-image: url({{project.coverImage}});{{/if}} {{#if project.color}}background-color: {{project.color}};{{/if}}">
+          <div class="project-list__card-notes">{{project.notes}}</div>
           {{#> components/text type="h3" class="project-list__card-title"}}
             {{project.title}}
+          {{/ components/text}}
+          {{#> components/text type="p" class="project-list__card-description"}}
+            {{project.description}}
           {{/ components/text}}
         </a>
       </li>
     {{/each}}
   </ul>
 </nav>
+

--- a/packages/app/src/_includes/components/project-list.hbs
+++ b/packages/app/src/_includes/components/project-list.hbs
@@ -1,9 +1,13 @@
-<div class="project-list">
-  {{#each (reverse projects) as |project|}}
-    <a rel="noreferrer external" target="_blank" href="{{project.url}}" class="project-list__card {{project.theme}}" style="background-image: url({{project.coverImage}});">
-      {{#> components/text as="h3" type="h3" class="project-list__card-title"}}
-        {{project.title}}
-      {{/ components/text}}
-    </a>
-  {{/each}}
-</div>
+<nav aria-label="Список проектов">
+  <ul class="project-list">
+    {{#each (reverse projects) as |project|}}
+      <li>
+        <a rel="noreferrer external" target="_blank" href="{{project.url}}" class="project-list__card {{project.theme}}" style="background-image: url({{project.coverImage}});">
+          {{#> components/text type="h3" class="project-list__card-title"}}
+            {{project.title}}
+          {{/ components/text}}
+        </a>
+      </li>
+    {{/each}}
+  </ul>
+</nav>

--- a/packages/app/src/_includes/components/share.hbs
+++ b/packages/app/src/_includes/components/share.hbs
@@ -1,3 +1,5 @@
-<div class="share" data-id="share-button">
-  <div class="share__icon"></div>
+<div class="share">
+  <button class="share__button" data-id="share-button" aria-label="Поделиться">
+    <div aria-hidden="true" class="share__icon"></div>
+  </button>
 </div>

--- a/packages/app/src/_includes/components/stay-in-touch.hbs
+++ b/packages/app/src/_includes/components/stay-in-touch.hbs
@@ -1,6 +1,6 @@
-<section class="stay-in-touch">
+<section class="stay-in-touch" aria-labelledby="stay-in-touch-title">
   <div>
-    {{#> components/text type="h3"}}
+    {{#> components/text type="h3" as="h3" id="stay-in-touch-title"}}
       Оставайтесь на связи
     {{/ components/text}}
   </div>

--- a/packages/app/src/_includes/components/tag-list.hbs
+++ b/packages/app/src/_includes/components/tag-list.hbs
@@ -1,11 +1,15 @@
-<div class="tag-list">
-  {{#each tags as |tag|}}
-    {{#not (eq tag "posts")}}
-      <a href="{{{ append "/tags/" tag}}}" class="tag">
-        {{#> components/text as="span" type="bodyStrong" class=""}}
-          {{tag}}
-        {{/ components/text}}
-      </a>
-    {{/not}}
-  {{/each}}
-</div>
+<nav>
+  <ul class="tag-list" aria-label="Список тегов">
+    {{#each tags as |tag|}}
+      {{#not (eq tag "posts")}}
+        <li>
+          <a href="{{{ append "/tags/" tag}}}" class="tag">
+            {{#> components/text as="span" type="bodyStrong" class=""}}
+              {{tag}}
+            {{/ components/text}}
+          </a>
+        </li>
+      {{/not}}
+    {{/each}}
+  </ul>
+</nav>

--- a/packages/app/src/_includes/components/text.hbs
+++ b/packages/app/src/_includes/components/text.hbs
@@ -1,5 +1,5 @@
 {{#if as}}
-<{{as}} class="text{{#if type}} text_type_{{type}}{{/if}}{{#if class}} {{class}}{{/if}}">{{> @partial-block }}</{{as}}>
+<{{as}} {{#if id}}id="{{id}}"{{/if}} class="text{{#if type}} text_type_{{type}}{{/if}}{{#if class}} {{class}}{{/if}}">{{> @partial-block }}</{{as}}>
 {{else}}
-<span class="text{{#if type}} text_type_{{type}}{{/if}}{{#if class}} {{class}}{{/if}}">{{> @partial-block }}</span>
+<span {{#if id}}id="{{id}}"{{/if}} class="text{{#if type}} text_type_{{type}}{{/if}}{{#if class}} {{class}}{{/if}}">{{> @partial-block }}</span>
 {{/if}}

--- a/packages/app/src/_includes/layouts/next.webpack.hbs
+++ b/packages/app/src/_includes/layouts/next.webpack.hbs
@@ -8,9 +8,10 @@
     <div class="page{{#if pageType}} page_type_{{pageType}}{{/if}}">
       <div class="page__container">
         {{> components/header }}
-        <div class="page__content">
+        <main id="main-content-id" class="page__content">
+          <a id="skipped-link-id" tabindex="-1" class=""></a>
           {{{content}}}
-        </div>
+        </main>
         {{> components/footer }}
         {{> components/menu }}
       </div>

--- a/packages/app/src/_includes/layouts/post.webpack.hbs
+++ b/packages/app/src/_includes/layouts/post.webpack.hbs
@@ -8,7 +8,8 @@
     <div class="page">
       <div class="page__container">
         {{> components/header }}
-        <div class="page__content post line-numbers">
+        <main id="main-content-id" class="page__content post line-numbers">
+          <a id="skipped-link-id" tabindex="-1" class=""></a>
           {{#> components/text type="h1" as="h1"}}{{title}}{{/ components/text}}
           <div class="post__date">
             {{#> components/text type="captionStrong"}}
@@ -24,14 +25,16 @@
           <div class="post__content">
             {{{content}}}
           </div>
-        </div>
-        <div class="post__reactions reactions"></div>
+        </main>
+        <section class="post__reactions" aria-label="Оценить пост">
+          <ul class="reactions"></ul>
+        </section>
         {{> components/stay-in-touch }}
-        <div class="post__readmore">
-          {{#> components/text type="h3" as="h3" class="post__readmore-title"}}Вам может быть интересно{{/ components/text}}
-          {{> components/post-list popular="true" posts=(relatedPosts collections.posts page.url tags 3)}}
-        </div>
-        <div class="post-layer__up">
+        <section class="post__readmore" aria-labelledby="post-readmore-title">
+          {{#> components/text type="h3" as="h3" id="post-readmore-title" class="post__readmore-title"}}Вам может быть интересно{{/ components/text}}
+          {{> components/post-list postListTitle="Список постов" popular="true" posts=(relatedPosts collections.posts page.url tags 3)}}
+        </section>
+        <div class="post-layer__up" aria-hidden="true">
           <div class="post-layer__back">
             <i class="arrow arrow_type_up"></i>
             <i class="arrow arrow_type_down"></i>
@@ -41,7 +44,7 @@
         {{> components/menu }}
         {{> components/share }}
       </div>
-    </div>   
+    </div>
     <%= htmlWebpackPlugin.tags.bodyTags %>
     {{> components/scripts }}
     <script defer src="/assets/prism.js"></script>

--- a/packages/app/src/client/javascript/modules/a11y.ts
+++ b/packages/app/src/client/javascript/modules/a11y.ts
@@ -1,0 +1,27 @@
+function registerSkipToContent() {
+  const $toggler = document.querySelector('#a11y-skip-to-content') as HTMLButtonElement
+  const $main = document.querySelector('#main-content-id') as HTMLDivElement
+  const $skippedLink = document.querySelector('#skipped-link-id') as HTMLAnchorElement
+
+  if (!$toggler || !$main) {
+    return
+  }
+
+  // Focus toggler on Alt-0
+  window.addEventListener('keydown', (event) => {
+    if (event.type === 'keydown') {
+      if (event.code === 'Digit0' && event.altKey && !event.repeat) {
+        $toggler.focus()
+      }
+    }
+  }, false)
+
+  $toggler.addEventListener('click', () => {
+    $main.scrollIntoView({ behavior: 'smooth' })
+    $skippedLink?.focus()
+  })
+}
+
+export function registerA11y() {
+  registerSkipToContent()
+}

--- a/packages/app/src/client/javascript/modules/a11y.ts
+++ b/packages/app/src/client/javascript/modules/a11y.ts
@@ -18,7 +18,7 @@ function registerSkipToContent() {
 
   $toggler.addEventListener('click', () => {
     $main.scrollIntoView({ behavior: 'smooth' })
-    $skippedLink?.focus()
+    $skippedLink.focus()
   })
 }
 

--- a/packages/app/src/client/javascript/modules/menu.ts
+++ b/packages/app/src/client/javascript/modules/menu.ts
@@ -1,26 +1,35 @@
 export function registerMenuHandlers() {
   const $toggler = document.querySelector('.header__menu-toggler') as HTMLDivElement
   const $togglerCross = document.querySelector('.menu__toggler') as HTMLDivElement
-  const $menu = document.querySelector('.menu') as HTMLDivElement
-  const $menuOverlay = document.querySelector('.menu__overlay') as HTMLDivElement
+  const $dialog = document.querySelector('dialog.menu') as HTMLDialogElement
 
   function openMenu(event: MouseEvent) {
     event.preventDefault()
-    $menu.classList.add('menu_opened')
+    $dialog.showModal()
   }
 
   function closeMenu(event: MouseEvent) {
     event.preventDefault()
-    $menu.classList.remove('menu_opened')
+    $dialog.close()
+  }
+
+  function closeOnBackDropClick(event: MouseEvent) {
+    const { target, currentTarget } = event
+    const dialog = currentTarget
+    const isClickedOnBackDrop = target === dialog
+
+    if (isClickedOnBackDrop) {
+      closeMenu(event)
+    }
   }
 
   $toggler.addEventListener('click', openMenu)
-  $menuOverlay.addEventListener('click', closeMenu)
+  $dialog.addEventListener('click', closeOnBackDropClick)
   $togglerCross.addEventListener('click', closeMenu)
 
   document.addEventListener('keydown', (event: KeyboardEvent) => {
     if (event.key === 'Escape') {
-      $menu.classList.remove('menu_opened')
+      $dialog.close()
     }
   })
 }

--- a/packages/app/src/client/javascript/modules/postReactions.ts
+++ b/packages/app/src/client/javascript/modules/postReactions.ts
@@ -49,10 +49,12 @@ function renderItems(reactions: Reactions, wrapperEl: HTMLDivElement) {
   const content = Object.entries(reactions).map(([type, count]) => {
     const typedType = type as ReactionCode
     return `
-    <div class="reactions__item reaction" data-type="${type}">
-      <img class="reaction__image" src="${IMAGES_MAP[typedType]}" alt="${EMOJI_MAP[typedType]}" width="64" height="64" />
-      <div class="reaction__counter">${count}</div>
-    </div>
+    <li class="reactions__item reaction" data-type="${type}">
+      <button aria-label="Поставить реакцию ${typedType}">
+        <img aria-hidden="true" class="reaction__image" src="${IMAGES_MAP[typedType]}" alt="${EMOJI_MAP[typedType]}" width="64" height="64" />
+        <div class="reaction__counter" aria-label="Реакция поставлена ${count} раз">${count}</div>
+      </button>
+    </li>
     `
   })
 
@@ -78,14 +80,17 @@ function clientOptimisticUpdate(
 
   const imageEl = el.querySelector('.reaction__image') as HTMLImageElement
   const counterEl = el.querySelector('.reaction__counter') as HTMLDivElement
+  const button = el.querySelector('button') as HTMLButtonElement
 
   if (increaseValue) {
     el.classList.add('reaction_active')
+    button?.setAttribute('aria-current', 'true')
     imageEl.src = imageEl.src.replace('.svg', '.gif')
     counterEl.textContent = String(Number(counterEl.textContent) + 1)
   }
   else {
     el.classList.remove('reaction_active')
+    button?.removeAttribute('aria-current')
     imageEl.src = imageEl.src.replace('.gif', '.svg')
     counterEl.textContent = String(Number(counterEl.textContent) - 1)
   }

--- a/packages/app/src/client/javascript/modules/postReactions.ts
+++ b/packages/app/src/client/javascript/modules/postReactions.ts
@@ -84,13 +84,13 @@ function clientOptimisticUpdate(
 
   if (increaseValue) {
     el.classList.add('reaction_active')
-    button?.setAttribute('aria-current', 'true')
+    button.setAttribute('aria-current', 'true')
     imageEl.src = imageEl.src.replace('.svg', '.gif')
     counterEl.textContent = String(Number(counterEl.textContent) + 1)
   }
   else {
     el.classList.remove('reaction_active')
-    button?.removeAttribute('aria-current')
+    button.removeAttribute('aria-current')
     imageEl.src = imageEl.src.replace('.gif', '.svg')
     counterEl.textContent = String(Number(counterEl.textContent) - 1)
   }

--- a/packages/app/src/client/javascript/modules/prepareExternalLinks.ts
+++ b/packages/app/src/client/javascript/modules/prepareExternalLinks.ts
@@ -5,7 +5,8 @@ function isExternalLink(url = '') {
 
 export function prepareExternalLinks() {
   document.querySelectorAll('.post a').forEach((a) => {
-    if (isExternalLink(a.getAttribute('href'))) {
+    const href = a.getAttribute('href')
+    if (href && isExternalLink(href)) {
       a.setAttribute('rel', 'noreferrer external')
       a.setAttribute('target', '_blank')
     }

--- a/packages/app/src/client/javascript/modules/share.ts
+++ b/packages/app/src/client/javascript/modules/share.ts
@@ -12,9 +12,9 @@ export function isWebShareSupported() {
 }
 
 export function registerShare() {
-  const button = document.querySelector('[data-id=share-button') as HTMLButtonElement
+  const $button = document.querySelector('[data-id=share-button') as HTMLButtonElement
 
-  if (!button || !isWebShareSupported()) {
+  if (!$button || !isWebShareSupported()) {
     return
   }
 
@@ -23,7 +23,7 @@ export function registerShare() {
     url: window.location.href,
   }
 
-  button.addEventListener('click', (event: MouseEvent) => {
+  $button.addEventListener('click', (event: MouseEvent) => {
     try {
       event.preventDefault()
       navigator.share(shareData)

--- a/packages/app/src/client/javascript/modules/theme.ts
+++ b/packages/app/src/client/javascript/modules/theme.ts
@@ -41,7 +41,11 @@ export function registerThemeToggler() {
 
     setTheme(nextTheme)
 
-    $toggler?.setAttribute('aria-label', `Сменить тему на ${nextTheme === 'light' ? 'тёмную' : 'светлую'}`)
+    if (!$toggler) {
+      return
+    }
+
+    $toggler.setAttribute('aria-label', `Сменить тему на ${nextTheme === 'light' ? 'тёмную' : 'светлую'}`)
   }
 
   $toggler.addEventListener('click', onTogglerClick)

--- a/packages/app/src/client/javascript/modules/theme.ts
+++ b/packages/app/src/client/javascript/modules/theme.ts
@@ -31,11 +31,17 @@ export function registerThemeToggler() {
     return
   }
 
+  $toggler.setAttribute('aria-label', `Сменить тему на ${document.documentElement.getAttribute('data-theme') === 'light' ? 'тёмную' : 'светлую'}`)
+
   function onTogglerClick(event: MouseEvent) {
     event.preventDefault()
 
     const theme = document.documentElement.getAttribute('data-theme') as Theme
-    setTheme(theme === 'light' ? 'dark' : 'light')
+    const nextTheme = theme === 'light' ? 'dark' : 'light'
+
+    setTheme(nextTheme)
+
+    $toggler?.setAttribute('aria-label', `Сменить тему на ${nextTheme === 'light' ? 'тёмную' : 'светлую'}`)
   }
 
   $toggler.addEventListener('click', onTogglerClick)

--- a/packages/app/src/client/javascript/next.entry.ts
+++ b/packages/app/src/client/javascript/next.entry.ts
@@ -1,6 +1,8 @@
+import { registerA11y } from './modules/a11y'
 import { initCopyToClipboard as registerCopyToClipboard } from './modules/copy'
 import { registerMenuHandlers } from './modules/menu'
 import { registerQuiz } from './modules/quiz'
+
 import { registerThemeToggler, syncTheme } from './modules/theme'
 
 import '../stylesheets/next.entry.css'
@@ -8,10 +10,11 @@ import '../stylesheets/next.entry.css'
 syncTheme()
 
 document.addEventListener('DOMContentLoaded', () => {
-  document.body.classList.add('loaded')
-
   registerQuiz()
   registerMenuHandlers()
   registerCopyToClipboard()
   registerThemeToggler()
+  registerA11y()
+
+  document.body.classList.add('loaded')
 })

--- a/packages/app/src/client/javascript/post.entry.ts
+++ b/packages/app/src/client/javascript/post.entry.ts
@@ -1,4 +1,5 @@
 import registerImageZoom from 'medium-zoom'
+import { registerA11y } from './modules/a11y'
 import { registerTerminals } from './modules/bot/createBot'
 import { initCopyToClipboard as registerCopyToClipboard } from './modules/copy'
 import { lazyload as registerImageLazyload } from './modules/lazyload'
@@ -7,6 +8,7 @@ import { registerPostReactions } from './modules/postReactions'
 import { prepareExternalLinks as registerExternalLinks } from './modules/prepareExternalLinks'
 import { scroll as registerScrollTop } from './modules/scroll'
 import { registerShare } from './modules/share'
+
 import { registerThemeToggler, syncTheme } from './modules/theme'
 
 import '../stylesheets/post.entry.css'
@@ -29,4 +31,5 @@ document.addEventListener('DOMContentLoaded', () => {
   registerTerminals($terminals)
   registerShare()
   registerThemeToggler()
+  registerA11y()
 })

--- a/packages/app/src/client/stylesheets/modules/a11y-skip-to-content.css
+++ b/packages/app/src/client/stylesheets/modules/a11y-skip-to-content.css
@@ -1,0 +1,13 @@
+#a11y-skip-to-content {
+  position: fixed;
+  opacity: 0;
+  top: 5px;
+  left: 0;
+  transform: translateY(-600%);
+  transition: transform .3s;
+
+  &:focus {
+    opacity: 1;
+    transform: translateY(0);
+  }
+}

--- a/packages/app/src/client/stylesheets/modules/base.css
+++ b/packages/app/src/client/stylesheets/modules/base.css
@@ -79,6 +79,13 @@ ol {
   }
 }
 
+button.icon {
+  border: none;
+  background-color: transparent;
+  padding: 0;
+  cursor: pointer;
+}
+
 html[data-theme="dark"] img {
   filter: brightness(0.8) contrast(1.2);
 }
@@ -93,4 +100,15 @@ html[data-theme="dark"] img.inverting {
   html[data-theme="dark"] & {
     mix-blend-mode: screen;
   }
+}
+
+/* a11y */
+
+.visually-hidden {
+  clip: rect(1px 1px 1px 1px);
+  clip: rect(1px, 1px, 1px, 1px);
+  height: 1px;
+  overflow: hidden;
+  position: absolute;
+  width: 1px;
 }

--- a/packages/app/src/client/stylesheets/modules/base.css
+++ b/packages/app/src/client/stylesheets/modules/base.css
@@ -112,3 +112,17 @@ html[data-theme="dark"] img.inverting {
   position: absolute;
   width: 1px;
 }
+
+a:focus-visible,
+button:focus-visible {
+  outline: 2px solid var(--brand-color);
+  outline-offset: 2px;
+}
+
+.icon:focus-visible,
+.header__logo:focus-visible {
+  html[data-theme="dark"] & {
+    /* Inverted var(--brand-color) */
+    outline: 2px solid #040ee0;
+  }
+}

--- a/packages/app/src/client/stylesheets/modules/footer.css
+++ b/packages/app/src/client/stylesheets/modules/footer.css
@@ -1,4 +1,4 @@
-.footer {
+.footer .footer__list {
   display: flex;
   flex-direction: row;
   align-items: flex-end;
@@ -6,6 +6,8 @@
   padding-top: 58px;
   color: var(--secondary-text-color);
   line-height: 1;
+
+  list-style-type: none;
 }
 
 .footer__item_divider {

--- a/packages/app/src/client/stylesheets/modules/header.css
+++ b/packages/app/src/client/stylesheets/modules/header.css
@@ -12,24 +12,52 @@
   background-image: url("/assets/favicon192.png");
   background-repeat: no-repeat;
   background-size: 42px;
-  background-position-y: -10px;
+  background-position-y: -8px;
 
   html[data-theme="dark"] & {
     filter: invert(0.9);
   }
 }
 
-.header__right {
+.header__actions {
   display: flex;
-  gap: 8px;
+  gap: 12px;
+}
+
+.header__nav {
+  display: block;
+
+  @media (--viewport-mobile) {
+    display: none;
+  }
+}
+
+.header__nav-list {
+  list-style-type: none;
+  display: flex;
+  gap: 12px;
+  font-weight: 500;
+}
+
+.header__nav-list [aria-current="true"] a {
+  background: var(--brand-color);
+  color: var(--color-dark);
+}
+
+.header__nav-list a {
+  color: var(--text-color);
 }
 
 .header__menu-toggler {
-  display: block;
+  display: none;
   width: 24px;
   height: 24px;
   background-image: url("/assets/images/icons/code.svg");
   background-repeat: no-repeat;
+
+  @media (--viewport-mobile) {
+    display: block;
+  }
 }
 
 .header__theme-toggler {

--- a/packages/app/src/client/stylesheets/modules/menu.css
+++ b/packages/app/src/client/stylesheets/modules/menu.css
@@ -1,64 +1,31 @@
-.menu {
-  z-index: 5;
-}
-
 body:not(.loaded) .menu {
   display: none;
   opacity: 0;
 }
 
-.menu__overlay {
-  position: fixed;
-  bottom: 0;
-  left: 0;
-  right: 0;
-  top: 0;
-  background-color: rgba(0, 0, 0, 0.2);
+.menu::backdrop {
+  background: linear-gradient(270deg, rgba(0, 0, 0, .30) 60%, hsla(0, 0.00%, 52.90%, 0.40));
   transition: opacity 0.3s ease-in-out;
-  visibility: hidden;
-  opacity: 0;
-
-  .menu_opened & {
-    opacity: 1;
-    visibility: visible;
-  }
-
-  &::after {
-    content: '';
-    display: block;
-    position: relative;
-    top: 0;
-    left: 0;
-    width: 100%;
-    height: 100%;
-    background: linear-gradient(270deg, rgba(0, 0, 0, 0.15) 60%, rgba(217, 217, 217, 0) 100%);
-  }
 }
 
-.menu__content {
+.menu {
   position: fixed;
+  border: 0;
   right: 0;
   top: 0;
   bottom: 0;
   padding: 36px 24px;
+  padding-top: 72px;
   height: 100%;
   max-width: 320px;
   width: 85%;
   background: var(--background-color);
-  transform: translateX(100%);
-  transition: transform 0.3s ease-in-out;
   text-align: left;
   overflow-y: auto;
 
-  .menu_opened & {
-    transform: translate(0, 0);
-    visibility: visible;
-  }
-
-  .menu:not(.menu_opened) & {
-    animation: 1s fadeOut;
+  &[open] {
+    animation: 0.3s fadeIn;
     animation-fill-mode: forwards;
-    visibility: visible;
   }
 
   @media (--viewport-mobile) {
@@ -67,7 +34,6 @@ body:not(.loaded) .menu {
     max-width: 100%;
     border-top-left-radius: 35px;
     border-top-right-radius: 35px;
-    transform: translateY(100%);
   }
 }
 
@@ -75,19 +41,8 @@ body:not(.loaded) .menu {
   padding: 16px 0;
 }
 
-.menu__block-header {
-  padding: 8px 0;
-}
-
-.menu__header {
-  display: flex;
-  align-items: center;
-  justify-content: space-between;
-}
-
 .menu__toggler {
-  display: inline-block;
-  position: absolute;
+  position: fixed;
   right: 24px;
   top: 34px;
   width: 19px;
@@ -97,21 +52,23 @@ body:not(.loaded) .menu {
   background-size: 19px 19px;
 }
 
-.menu__logo {
-  display: block;
-  width: 42px;
-  height: 27px;
-  background-image: url(/assets/favicon192.png);
-  background-repeat: no-repeat;
-  background-size: 42px;
-  background-position-y: -10px;
-
-  html[data-theme="dark"] & {
-    filter: invert(0.9);
-  }
+.menu__nav-list {
+  list-style: none;
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+  font-weight: 500;
 }
 
-@keyframes fadeOut {
-  99% { visibility: visible; }
-  100% { visibility: hidden; }
+.menu__nav-list a {
+  color: var(--text-color);
+}
+
+@keyframes fadeIn{
+  0% {
+    transform: translateY(100%);
+  }
+  100% {
+    transform: translateY(0);
+  }
 }

--- a/packages/app/src/client/stylesheets/modules/menu.css
+++ b/packages/app/src/client/stylesheets/modules/menu.css
@@ -6,6 +6,10 @@ body:not(.loaded) .menu {
 .menu::backdrop {
   background: linear-gradient(270deg, rgba(0, 0, 0, .30) 60%, hsla(0, 0.00%, 52.90%, 0.40));
   transition: opacity 0.3s ease-in-out;
+
+  html[data-theme="dark"] & {
+    background: linear-gradient(270deg, rgba(255, 255, 255, .15) 60%, hsla(0, 0.00%, 52.90%, 0.20));
+  }
 }
 
 .menu {

--- a/packages/app/src/client/stylesheets/modules/menu.css
+++ b/packages/app/src/client/stylesheets/modules/menu.css
@@ -14,31 +14,39 @@ body:not(.loaded) .menu {
 
 .menu {
   position: fixed;
-  border: 0;
   right: 0;
   top: 0;
   bottom: 0;
-  padding: 36px 24px;
-  padding-top: 72px;
+
+  border: 0;
+  padding: 0;
+  padding-bottom: 36px;
+
   height: 100%;
   max-width: 320px;
-  width: 85%;
+  width: 100%;
   background: var(--background-color);
   text-align: left;
   overflow-y: auto;
 
   &[open] {
+    display: flex;
     animation: 0.3s fadeIn;
     animation-fill-mode: forwards;
   }
 
   @media (--viewport-mobile) {
     top: 16px;
-    width: calc(100vw - 48px);
+    width: 100vw;
     max-width: 100%;
     border-top-left-radius: 35px;
     border-top-right-radius: 35px;
   }
+}
+
+.menu__content {
+  padding: 72px 24px;
+  width: 100%;
 }
 
 .menu__block {

--- a/packages/app/src/client/stylesheets/modules/pagination.css
+++ b/packages/app/src/client/stylesheets/modules/pagination.css
@@ -1,5 +1,9 @@
 .pagination {
   padding: 30px 0;
+}
+
+.pagination ul {
+  list-style-type: none;
   display: flex;
   justify-content: space-between;
 }

--- a/packages/app/src/client/stylesheets/modules/post-list.css
+++ b/packages/app/src/client/stylesheets/modules/post-list.css
@@ -6,6 +6,8 @@
   max-width: 100%;
   padding-top: 8px;
 
+  list-style-type: none;
+
   @media (--viewport-mobile) {
     grid-template-columns: repeat(1, minmax(0, 1fr));
   }
@@ -24,7 +26,7 @@
   }
 }
 
-a.post-list__card {
+.post-list__card {
   position: relative;
   display: flex;
   flex-direction: column;
@@ -73,6 +75,14 @@ a.post-list__card {
     z-index: 1;
     content: "";
   }
+}
+
+.post-list__card a {
+  position: absolute;
+  top: 0;
+  left: 0;
+  bottom: 0;
+  right: 0;
 }
 
 .post-list__card-title {
@@ -138,4 +148,10 @@ a.post-list__card {
     font-size: 19px;
     filter: none !important;
   }
+}
+
+.post-list__card-content {
+  display: flex;
+  height: 100%;
+  flex-direction: column;
 }

--- a/packages/app/src/client/stylesheets/modules/project-list.css
+++ b/packages/app/src/client/stylesheets/modules/project-list.css
@@ -17,6 +17,7 @@ a.project-list__card {
   display: flex;
   flex-direction: column;
   justify-content: flex-end;
+  gap: 12px;
   padding: 16px 20px;
   min-height: 200px;
   color: var(--color-white);
@@ -24,14 +25,41 @@ a.project-list__card {
   background-size: cover;
   box-sizing: border-box;
   border-radius: 24px;
-  transition: all 0.3s ease-in-out;
+  transition: transform 0.3s ease-in-out;
 
   &:hover {
     transform: scale(0.95);
   }
+
+  &::before {
+    content: "";
+    display: block;
+    position: absolute;
+    top: 0;
+    right: 0;
+    bottom: 0;
+    left: 0;
+    border-radius: 24px;
+    background-image: linear-gradient(45deg, #fff0, #fff0 60%, #ffffff1a 85%, #ffffff1a 90%, #ffffff0d);
+  }
 }
 
-.project-list__card-title {
+.project-list__card-notes {
+  position: absolute;
+  top: 16px;
+  right: 16px;
+  color: var(--color-white);
+  font-size: 12px;
+  font-weight: 500;
+  line-height: 1;
+
+  .light & {
+    color: var(--color-dark);
+  }
+}
+
+.project-list__card-title,
+.project-list__card-description {
   color: var(--color-white);
   line-height: 1;
   padding-top: 0;

--- a/packages/app/src/client/stylesheets/modules/project-list.css
+++ b/packages/app/src/client/stylesheets/modules/project-list.css
@@ -5,6 +5,7 @@
   gap: 16px;
   max-width: 100%;
   padding-top: 8px;
+  list-style-type: none;
 
   @media (--viewport-mobile) {
     grid-template-columns: repeat(1, minmax(0, 1fr));

--- a/packages/app/src/client/stylesheets/modules/reactions.css
+++ b/packages/app/src/client/stylesheets/modules/reactions.css
@@ -6,6 +6,7 @@
   padding: 24px;
   border-radius: 35px;
   background: var(--secondary-background-color);
+  list-style-type: none;
 }
 
 .reaction {
@@ -17,6 +18,14 @@
     backface-visibility: hidden;
     perspective: 1000px;
   }
+}
+
+.reaction button {
+  border: none;
+  background: transparent;
+  padding: 0;
+  margin: 0;
+  cursor: pointer;
 }
 
 .reaction__image {
@@ -39,6 +48,8 @@
   display: flex;
   justify-content: center;
   align-items: center;
+  font-family: 'Fira Sans', sans-serif;
+  font-size: 16px;
   font-weight: 700;
   position: absolute;
   top: 0;

--- a/packages/app/src/client/stylesheets/modules/share.css
+++ b/packages/app/src/client/stylesheets/modules/share.css
@@ -3,17 +3,24 @@
   display: none;
   bottom: 20px;
   right: 20px;
-  background: var(--text-color);
-  color: var(--background-color);
-  border-radius: 50%;
-  padding: 8px;
-  width: 24px;
-  height: 24px;
-  cursor: pointer;
 
   @media (--viewport-mobile) {
     display: block;
   }
+}
+
+.share__button {
+  border: none;
+  border-radius: 50%;
+  background: transparent;
+  padding: 0;
+  margin: 0;
+  cursor: pointer;
+  background: var(--text-color);
+  color: var(--background-color);
+  padding: 8px;
+  width: 40px;
+  height: 40px;
 }
 
 .share__icon {

--- a/packages/app/src/client/stylesheets/modules/stay-in-touch.css
+++ b/packages/app/src/client/stylesheets/modules/stay-in-touch.css
@@ -3,6 +3,7 @@
   flex-direction: column;
   gap: 16px;
   padding: 24px;
+  padding-top: 8px;
   border-radius: 35px;
   background: var(--secondary-background-color);
   margin-top: 32px;

--- a/packages/app/src/client/stylesheets/modules/tags-list.css
+++ b/packages/app/src/client/stylesheets/modules/tags-list.css
@@ -4,6 +4,7 @@
   align-items: center;
   gap: 10px 4px;
   padding: 8px 0;
+  list-style-type: none;
 }
 
 a.tag {

--- a/packages/app/src/client/stylesheets/next.entry.css
+++ b/packages/app/src/client/stylesheets/next.entry.css
@@ -3,6 +3,7 @@
 @import url("./modules/colors.css");
 @import url("./modules/page.css");
 @import url("./modules/base.css");
+@import url("./modules/a11y-skip-to-content.css");
 
 /* Common components */
 @import url("./modules/text.css");

--- a/packages/app/src/client/stylesheets/post.entry.css
+++ b/packages/app/src/client/stylesheets/post.entry.css
@@ -3,6 +3,7 @@
 @import url("./modules/colors.css");
 @import url("./modules/page.css");
 @import url("./modules/base.css");
+@import url("./modules/a11y-skip-to-content.css");
 
 /* Common components */
 @import url("./modules/text.css");

--- a/packages/app/src/pages/blog.hbs
+++ b/packages/app/src/pages/blog.hbs
@@ -14,26 +14,31 @@ permalink: /blog/{{#if (not (eq pagination.pageNumber 0))}}page/{{pagination.pag
 {{#> components/text type="h1" as="h1"}}Блог о веб-разработке{{/ components/text}}
 
 {{#if (eq pagination.pageNumber 0)}}
-  {{#> components/text type="h2" as="h2"}}Лучшие посты{{/ components/text}}
-
-  {{> components/post-list popular="true" posts=(reverse collections.popularPosts)}}
+  <section aria-labelledby="popular-posts-title">
+    {{#> components/text type="h2" as="h2" id="popular-posts-title"}}Популярные посты{{/ components/text}}
+    {{> components/post-list postListTitle="Список популярных постов" popular="true" posts=(reverse collections.popularPosts)}}
+  </section>
 {{/if}}
 
-{{#> components/text type="h2" as="h2"}}
-  {{#if (not (eq pagination.pageNumber 0))}}
-    Cтраница {{plus pagination.pageNumber 1}} из {{paginationSize pagination.data.length pagination.size}}
-  {{else}}
-    Последние посты
-  {{/if}}
-{{/ components/text}}
+<section aria-labelledby="posts-title">
+  {{#> components/text type="h2" as="h2" id="posts-title"}}
+    {{#if (not (eq pagination.pageNumber 0))}}
+      Cтраница {{plus pagination.pageNumber 1}} из {{paginationSize pagination.data.length pagination.size}}
+    {{else}}
+      Последние посты
+    {{/if}}
+  {{/ components/text}}
 
-{{> components/post-list posts=(reverse pagination.items)}}
+  {{> components/post-list postListTitle="Список последних постов" posts=(reverse pagination.items)}}
 
-{{> components/pagination pagination=pagination}}
+  {{> components/pagination pagination=pagination}}
+</section>
 
 {{#if (eq pagination.pageNumber 0)}}
-  {{#> components/text type="h2" as="h2"}}Проекты{{/ components/text}}
-  {{> components/project-list projects=projects}}
+  <section aria-labelledby="projects-title">
+    {{#> components/text type="h2" as="h2" id="projects-title"}}Проекты{{/ components/text}}
+    {{> components/project-list projects=projects}}
+  </section>
 {{/if}}
 
 {{> components/stay-in-touch }}

--- a/packages/app/src/pages/blog.hbs
+++ b/packages/app/src/pages/blog.hbs
@@ -34,12 +34,5 @@ permalink: /blog/{{#if (not (eq pagination.pageNumber 0))}}page/{{pagination.pag
   {{> components/pagination pagination=pagination}}
 </section>
 
-{{#if (eq pagination.pageNumber 0)}}
-  <section aria-labelledby="projects-title">
-    {{#> components/text type="h2" as="h2" id="projects-title"}}Проекты{{/ components/text}}
-    {{> components/project-list projects=projects}}
-  </section>
-{{/if}}
-
 {{> components/stay-in-touch }}
 

--- a/packages/app/src/pages/home.hbs
+++ b/packages/app/src/pages/home.hbs
@@ -10,7 +10,7 @@ pageType: home
 <p>Я Александр. Я <i>software engineer</i> больше извесный как @saaaaaaaaasha</p>
 <p>
   {{#> components/text type="h4"}}
-    Пишу о {{#> components/link href="/tags/react"}}#реакте{{/ components/link}}, {{#> components/link href="/tags/typescript"}}#тайпскрипте{{/ components/link}}, {{#> components/link href="/tags/nodejs"}}#ноде{{/ components/link}} и
+    Пишу о {{#> components/link href="/tags/react"}}#реакте{{/ components/link}}, {{#> components/link href="/tags/typescript"}}#тайпскрипте{{/ components/link}}, {{#> components/link href="/tags/fsd"}}#fsd{{/ components/link}} и
     обо всем том, что связяно с веб-разработкой. Гоу в {{#> components/link href="/blog"}}блог{{/ components/link}}.
   {{/ components/text}}
 </p>

--- a/packages/app/src/pages/projects.hbs
+++ b/packages/app/src/pages/projects.hbs
@@ -1,0 +1,10 @@
+---
+layout: layouts/next.hbs
+title: Проекты
+description: Реализованные проекты
+permalink: /projects/
+---
+
+{{#> components/text type="h1" as="h1"}}Проекты{{/ components/text}}
+
+{{> components/project-list projects=projects}}

--- a/packages/app/src/pages/talks.hbs
+++ b/packages/app/src/pages/talks.hbs
@@ -1,0 +1,53 @@
+---
+layout: layouts/next.hbs
+title: Выступления
+description: Выступления на конференциях и митапах
+permalink: /talks/
+---
+
+{{#> components/text type="h1" as="h1"}}Выступления{{/ components/text}}
+
+<style>
+  .talks-list-container {
+    display: flex;
+    flex-direction: column-reverse;
+    gap: 1rem;
+  }
+
+  .talks-list-container a + a::before {
+    content: ' / ';
+    display: inline-block;
+    padding-right: 0.3rem;
+  }
+  
+  .talks-list {
+    display: flex;
+    flex-direction: column;
+    gap: 1rem;
+  }
+
+  .talks-list > li > a:first-child {
+    background-color: var(--brand-color);
+    color: var(--color-dark);
+  }
+</style>
+
+<nav aria-label="Список выступлений" class="talks-list-container">
+  {{#each talks as |talkInYear|}}
+    <div>
+      {{#> components/text type="h1" as="h2"}}{{@key}}{{/ components/text}}
+
+      <ul class="talks-list">
+        {{#each talkInYear as |talk|}}
+          <li>
+            <a href="{{talk.conferenceUrl}}" target="_blank" rel="noopener noreferrer"><strong>{{talk.conference}}</strong></a> / <strong>{{talk.title}}</strong>
+            <br />
+            ({{#if talk.videoUrl}}<a href="{{talk.videoUrl}}">🍿 Video</a>{{/if}}
+              {{#if talk.slidesUrl}}<a href="{{talk.slidesUrl}}">📸 Slides</a>{{/if}}
+              {{#if talk.materialsUrl}}<a href="{{talk.materialsUrl}}">📒 Materials</a>{{/if}})
+          </li>
+        {{/each}}
+      </ul>
+    </div>
+  {{/each}}
+</nav>


### PR DESCRIPTION
### base

- add skip to content button (with Options/Alt + 0 hotkey)
- make semantic blocks for header/footer/main/sections and so on
- add semantic buttons (just change from a/div to button html tag)
- change custom modal to dialog
- wrap all lists to nav+ul+li semantic tags

### addition changes

- add talks and project separate pages
- 